### PR TITLE
only change behavior of methods of ActiveSupport::TimeWithZone while using dynamic time zone

### DIFF
--- a/lib/dynamic_time_zone/time_with_zone_patch.rb
+++ b/lib/dynamic_time_zone/time_with_zone_patch.rb
@@ -2,14 +2,18 @@
 
 module TimeWithZonePatch
   def localtime(utc_offset = nil)
-    return super unless DynamicTimeZone.enabled
+    return super unless using_dynamic_time_zone?
 
     utc + (utc_offset || 0).seconds
   end
   alias_method :getlocal, :localtime
 
   def formatted_offset(*args)
-    DynamicTimeZone.enabled ? '+0000' : super
+    using_dynamic_time_zone? ? '+0000' : super
+  end
+
+  def using_dynamic_time_zone?
+    DynamicTimeZone::Validator.new.valid?(time_zone.name)
   end
 end
 

--- a/spec/dynamic_time_zone/time_with_zone_patch_spec.rb
+++ b/spec/dynamic_time_zone/time_with_zone_patch_spec.rb
@@ -9,7 +9,8 @@ describe TimeWithZonePatch do
 
   low_offset_timezone = 'DynamicTimeZone/+36000'
   high_offset_timezone = 'DynamicTimeZone/+3600000'
-  timezones = [low_offset_timezone, high_offset_timezone]
+  normal_offset_timezone = 'America/Los_Angeles'
+  dynamic_timezones = [low_offset_timezone, high_offset_timezone]
 
   let(:strftime_now) { Time.zone.now.strftime('%Y-%m-%d %H:%M:%S') }
   let(:now_default_to_s) { Time.zone.now.to_s(:default) }
@@ -21,7 +22,7 @@ describe TimeWithZonePatch do
       end
     end
 
-    timezones.each do |timezone|
+    dynamic_timezones.each do |timezone|
       it "strftime does not raise error with timezone #{timezone}" do
         Time.zone = timezone
         expect { strftime_now }.not_to raise_error
@@ -31,6 +32,11 @@ describe TimeWithZonePatch do
         Time.zone = timezone
         expect(now_default_to_s).to end_with('+0000')
       end
+    end
+
+    it "to_s does not end with +0000 with timezone #{normal_offset_timezone}" do
+      Time.zone = normal_offset_timezone
+      expect(now_default_to_s).not_to end_with('+0000')
     end
   end
 

--- a/spec/dynamic_time_zone/validator_spec.rb
+++ b/spec/dynamic_time_zone/validator_spec.rb
@@ -6,9 +6,17 @@ describe DynamicTimeZone::Validator do
   let(:invalid_input1){ 'DynamicTimeYone/+2000' }
   let(:invalid_input2){ 'DynamicTimeZone/@2000' }
   let(:valid_input){ 'DynamicTimeZone/+2000' }
+  let(:unrelated_input){ 'America/Los_Angeles' }
 
   it 'returns false if the module is not enabled' do
     expect(described_class.new.valid?(valid_input)).to be false
+  end
+
+  it 'returns false if the input is unrelated' do
+    expect(described_class.new.valid?(unrelated_input)).to be false
+    with_isolated_time_zone_and_dynamic_time_zone_setting do
+      expect(described_class.new.valid?(unrelated_input)).to be false
+    end
   end
 
   it 'returns false if the module is enabled and input is invalid' do


### PR DESCRIPTION
This line should check for the time zone to be dynamic
 https://github.com/appfolio/dynamic_time_zone/blob/5a6a90525d2b32beee7e6d7d57e33e54943043b7/lib/dynamic_time_zone/time_with_zone_patch.rb#L12

We don't want to overwrite logic of ActiveSupport if it is not using DynamicTimeZone.