### PR TITLE
only override tz offset if greater than 24 hours

### DIFF
--- a/lib/dynamic_time_zone/time_with_zone_patch.rb
+++ b/lib/dynamic_time_zone/time_with_zone_patch.rb
@@ -9,7 +9,11 @@ module TimeWithZonePatch
   alias_method :getlocal, :localtime
 
   def formatted_offset(*args)
-    using_dynamic_time_zone? ? '+0000' : super
+    actual_formatted_offset = super
+    return actual_formatted_offset unless using_dynamic_time_zone?
+
+    seconds_in_24_hours = 24 * 60 * 60
+    utc_offset.abs > seconds_in_24_hours ?  '+0000' : actual_formatted_offset
   end
 
   def using_dynamic_time_zone?

--- a/spec/dynamic_time_zone/time_with_zone_patch_spec.rb
+++ b/spec/dynamic_time_zone/time_with_zone_patch_spec.rb
@@ -7,10 +7,17 @@ describe TimeWithZonePatch do
     TZInfo::DataSource.set(DynamicTimeZone::TimeZoneDataSource.new)
   end
 
-  low_offset_timezone = 'DynamicTimeZone/+36000'
-  high_offset_timezone = 'DynamicTimeZone/+3600000'
+  low_positive_offset_timezone = 'DynamicTimeZone/+36000'
+  high_positive_offset_timezone = 'DynamicTimeZone/+3600000'
+  low_negative_offset_timezone = 'DynamicTimeZone/-36000'
+  high_negative_offset_timezone = 'DynamicTimeZone/-3600000'
   normal_offset_timezone = 'America/Los_Angeles'
-  dynamic_timezones = [low_offset_timezone, high_offset_timezone]
+  dynamic_timezones = [
+    low_positive_offset_timezone,
+    high_positive_offset_timezone,
+    low_negative_offset_timezone,
+    high_negative_offset_timezone
+  ]
 
   let(:strftime_now) { Time.zone.now.strftime('%Y-%m-%d %H:%M:%S') }
   let(:now_default_to_s) { Time.zone.now.to_s(:default) }
@@ -27,11 +34,30 @@ describe TimeWithZonePatch do
         Time.zone = timezone
         expect { strftime_now }.not_to raise_error
       end
+    end
 
+    [high_negative_offset_timezone, high_positive_offset_timezone].each do |timezone|
       it "default to_s ends with +0000 with timezone #{timezone}" do
         Time.zone = timezone
         expect(now_default_to_s).to end_with('+0000')
       end
+    end
+
+    [low_negative_offset_timezone, low_positive_offset_timezone].each do |timezone|
+      it "to_s does not end with +0000 with timezone #{timezone}" do
+        Time.zone = timezone
+        expect(now_default_to_s).not_to end_with('+0000')
+      end
+    end
+
+    it "default to_s ends with -1000 with timezone #{low_negative_offset_timezone}" do
+      Time.zone = low_negative_offset_timezone
+      expect(now_default_to_s).to end_with('-1000')
+    end
+
+    it "default to_s ends with +1000 with timezone #{low_positive_offset_timezone}" do
+      Time.zone = low_positive_offset_timezone
+      expect(now_default_to_s).to end_with('+1000')
     end
 
     it "to_s does not end with +0000 with timezone #{normal_offset_timezone}" do
@@ -45,18 +71,18 @@ describe TimeWithZonePatch do
       DynamicTimeZone.enabled = false
     end
 
-    it "strftime does not raise error with timezone #{low_offset_timezone}" do
-      Time.zone = low_offset_timezone
+    it "strftime does not raise error with timezone #{low_positive_offset_timezone}" do
+      Time.zone = low_positive_offset_timezone
       expect { strftime_now }.not_to raise_error
     end
 
-    it "default to_s ends with +1000 with timezone #{low_offset_timezone}" do
-      Time.zone = low_offset_timezone
+    it "default to_s ends with +1000 with timezone #{low_positive_offset_timezone}" do
+      Time.zone = low_positive_offset_timezone
       expect(now_default_to_s).to end_with('+1000')
     end
 
-    it "strftime raise error with timezone #{high_offset_timezone}" do
-      Time.zone = high_offset_timezone
+    it "strftime raise error with timezone #{high_positive_offset_timezone}" do
+      Time.zone = high_positive_offset_timezone
       expect { strftime_now }.to raise_error(ArgumentError)
     end
   end


### PR DESCRIPTION
The time zone offset for dynamic time zones was previously set to
+0000 to avoid the front-end parsing logic raising an exception.
However, the exception only happens if the if the time zone offset is
greater than 24 hours, so the mitigation does not need to be quite so
aggressive.